### PR TITLE
!feat/refactor: use config instead of global vars

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
 
-from modules.utils import get_user_id
-
 
 @dataclass
 class _Config:
-    USER_ID: str = get_user_id()
+    USER_ID: str = ""  # gets updated in main.py when app starts, changed to remove circular import
     kliks: int = 0
     level: int = 1
     exp: int = 0


### PR DESCRIPTION
I am still working toward solving #4 

First commit is just changing the code so that it uses the config vars instead of globals which will be hard to sync across the modules once more are implemented or the project needs to be rearranged.

I found that the `load_variables()` function is not used, I might move that to the config section later so it can directly update the config from there.